### PR TITLE
Implement session-based login with timeout

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -31,6 +31,8 @@ const usuariosLower = {
   "peterson": "12345"
 };
 
+const SESSION_DURATION = 60 * 60 * 1000; // 1 hora em milissegundos
+
 function login() {
   let usuarioInput = document.getElementById('usuario').value.trim().toLowerCase();
   usuarioInput = removeAcentos(usuarioInput);
@@ -38,10 +40,35 @@ function login() {
   const erro = document.getElementById('erro');
 
   if (usuariosLower[usuarioInput] && usuariosLower[usuarioInput] === senhaInput) {
+    const now = Date.now();
     sessionStorage.setItem('logadoCamargo', 'sim');
     sessionStorage.setItem('usuarioCamargo', usuarioInput.charAt(0).toUpperCase() + usuarioInput.slice(1));
+    sessionStorage.setItem('loginTimeCamargo', now.toString());
+    setTimeout(logout, SESSION_DURATION);
     window.location.href = 'index.html';
   } else {
     erro.style.display = 'block';
   }
+}
+
+function logout() {
+  sessionStorage.clear();
+  window.location.href = 'login.html';
+}
+
+function checkAuth() {
+  const logado = sessionStorage.getItem('logadoCamargo') === 'sim';
+  const loginTime = parseInt(sessionStorage.getItem('loginTimeCamargo'), 10);
+
+  if (!logado || isNaN(loginTime) || (Date.now() - loginTime) > SESSION_DURATION) {
+    sessionStorage.clear();
+    if (!window.location.pathname.endsWith('login.html')) {
+      window.location.href = 'login.html';
+    }
+    return false;
+  }
+
+  const restante = SESSION_DURATION - (Date.now() - loginTime);
+  setTimeout(logout, restante);
+  return true;
 }

--- a/fichaatendimento.html
+++ b/fichaatendimento.html
@@ -19,6 +19,8 @@
   </style>
 </head>
 <body>
+  <script src="auth.js"></script>
+  <script>checkAuth();</script>
   <h2>Ficha de Atendimento ao Cliente</h2>
   <label>Quantos clientes?
     <input type="number" id="qtdClientes" min="1" max="10" value="1" onchange="gerarTabela()">

--- a/index.html
+++ b/index.html
@@ -73,13 +73,8 @@
   </style>
 </head>
 <body>
-
-  <!-- Proteção: redireciona se não estiver logado -->
-  <script>
-    if (sessionStorage.getItem("logadoCamargo") !== "sim") {
-      window.location.href = "login.html";
-    }
-  </script>
+  <script src="auth.js"></script>
+  <script>checkAuth();</script>
 
   <div class="painel-box">
     <h2>Bem-vindo(a), <span id="nomeUsuario"></span> 👋</h2>
@@ -104,11 +99,6 @@
 
     const nome = sessionStorage.getItem("usuarioCamargo");
     document.getElementById("nomeUsuario").textContent = capitalizar(nome);
-
-    function logout() {
-      sessionStorage.clear();
-      location.href = "login.html";
-    }
   </script>
 
 </body>

--- a/login.html
+++ b/login.html
@@ -73,57 +73,7 @@
     <div id="erro">Usuário ou senha incorretos!</div>
   </div>
 
-  <script>
-    // Função para remover acentos
-    function removeAcentos(str) {
-      return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-    }
-
-    // Lista de usuários e senhas (usuário formatado: minúsculo e sem acento)
-    const usuarios = {
-      "guilherme": "12345",
-      "alex": "12345",
-      "katlrin": "12345",
-      "eduarda": "12345",
-      "brayan": "12345",
-      "maykon": "12345",
-      "lucas": "12345",
-      "osvaldo": "12345",
-      "paulo": "12345",
-      "fossile": "12345",
-      "frigheto": "12345",
-      "deivison": "12345",
-      "thiago": "12345",
-      "hernane": "12345",
-      "silvio": "12345",
-      "anna": "12345",
-      "sergio": "12345",
-      "jhony": "12345",
-      "joao": "12345",
-      "anderson": "12345",
-      "kaleu": "12345",
-      "geison": "12345",
-      "peterson": "12345",
-      "patrick": "12345",
-      "michael": "12345"
-    };
-
-    function login() {
-      const usuarioInput = document.getElementById('usuario').value.trim();
-      const senhaInput = document.getElementById('senha').value.trim();
-      const erro = document.getElementById('erro');
-
-      const usuarioFormatado = removeAcentos(usuarioInput.toLowerCase());
-
-      if (usuarios[usuarioFormatado] && usuarios[usuarioFormatado] === senhaInput) {
-        sessionStorage.setItem('logadoCamargo', 'sim');
-        sessionStorage.setItem('usuarioCamargo', usuarioFormatado);
-        window.location.href = 'index.html';
-      } else {
-        erro.style.display = 'block';
-      }
-    }
-  </script>
+  <script src="auth.js"></script>
 
 </body>
 </html>

--- a/protocolo.html
+++ b/protocolo.html
@@ -24,6 +24,8 @@
 </style>
 </head>
 <body class="bg-light">
+<script src="auth.js"></script>
+<script>checkAuth();</script>
 
 <div class="container my-4">
   <h1 class="mb-3 text-center fw-bold">Imobiliária Camargo – Gerador de Protocolo de Contrato</h1>

--- a/simulador.html
+++ b/simulador.html
@@ -16,6 +16,8 @@
     </style>
 </head>
 <body>
+  <script src="auth.js"></script>
+  <script>checkAuth();</script>
 
 <h1>Simulador de Obra</h1>
 

--- a/trocar-senha.html
+++ b/trocar-senha.html
@@ -35,6 +35,8 @@
   </style>
 </head>
 <body>
+  <script src="auth.js"></script>
+  <script>checkAuth();</script>
 
   <div class="box">
     <h2>Trocar Senha</h2>
@@ -52,9 +54,8 @@
         return;
       }
 
-      // Salva nova senha no localStorage
-      localStorage.setItem(`senha_${usuario}`, novaSenha);
-      localStorage.setItem(`senhaTrocada_${usuario}`, "sim");
+      // Exemplo de salvamento apenas em memória da sessão
+      sessionStorage.setItem(`senha_${usuario}`, novaSenha);
       alert("Senha alterada com sucesso!");
       window.location.href = "index.html";
     }


### PR DESCRIPTION
## Summary
- centralize login logic in `auth.js`
- enforce one-hour session timeout
- include auth checks on every page
- remove inline login scripts
- avoid localStorage usage when changing password

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68683634c26883299a9c7d676501e488